### PR TITLE
Fix makefile to use pvsneslib submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Developer Tips
+
+Before making code changes:
+1. Initialize and build the bundled PVSnesLib toolchain:
+   ```bash
+   git submodule update --init
+   PVSNESLIB_HOME=$PWD/pvsneslib make -C pvsneslib
+   ```
+2. After the toolchain is built, running `make` should produce `hello.sfc`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-SNESDEV ?= $(HOME)/snesdev
-include $(SNESDEV)/pvsneslib/snes_rules
+PVSNESLIB_HOME ?= $(CURDIR)/pvsneslib
+include $(PVSNESLIB_HOME)/devkitsnes/snes_rules
+
+# Add PVSnesLib headers to the assembler search path
+override AS := $(PVSNESLIB_HOME)/devkitsnes/bin/wla-65816 -I$(PVSNESLIB_HOME)/devkitsnes/include
 
 TARGET = hello
 SOURCES = src/main.c

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ This project demonstrates a minimal Super Nintendo (SNES) program written in C. 
 
 ## Requirements
 
-- [pvsneslib](https://github.com/alekmaul/pvsneslib) toolchain installed at `$HOME/snesdev`. This provides the compiler, linker and standard libraries required for SNES development.
+- Submodule [pvsneslib](https://github.com/alekmaul/pvsneslib) checked out in `pvsneslib/`. It contains the compiler, linker and standard libraries required for SNES development.
 
 ## Building
 
-1. Ensure `SNESDEV` environment variable points to your pvsneslib installation. By default it uses `$HOME/snesdev`.
+1. Initialize the submodule once after cloning:
+   ```
+   git submodule update --init
+   ```
+   The Makefile automatically uses `pvsneslib` as `PVSNESLIB_HOME`.
 2. Run `make` to build `hello.sfc`.
 
 ```

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,10 @@
 #include <snes.h>
 
 int main(void) {
-    consoleDemoInit();
+    consoleInit();
     consoleDrawText(10, 10, "Hello World");
-    while(1) {
+    setScreenOn();
+    while (1) {
         WaitForVBlank();
     }
     return 0;


### PR DESCRIPTION
## Summary
- reference the pvsneslib submodule in Makefile
- document using the submodule in the README
- add AGENTS guidelines for setting up the toolchain
- replace deprecated consoleDemoInit() call

## Testing
- `PVSNESLIB_HOME=$PWD/pvsneslib make -C pvsneslib`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6859f22a67d08326b4e311e26f392e80